### PR TITLE
Use new version of /clusters endpoint

### DIFF
--- a/kostyor_cli/main.py
+++ b/kostyor_cli/main.py
@@ -96,8 +96,18 @@ class ClusterDiscovery(ShowOne):
 class ClusterList(Lister):
     def take_action(self, parsed_args):
         columns = ('Cluster Name', 'Cluster ID', 'Status')
-        data = requests.get('http://{}:{}/clusters'.format(host, port))
-        clusters = data.json()['clusters']
+        data = requests.get('http://{}:{}/clusters'.format(host, port)).json()
+
+        # FIXME: This step is required as intermediate in order to do not
+        #        break integration tests in Kostyor. When patch [1] is
+        #        lander we can remove this code.
+        #
+        #        [1]: https://github.com/sc68cal/Kostyor/pull/39
+        if isinstance(data, list):
+            clusters = data.json()
+        else:
+            clusters = data.json()['clusters']
+
         output = ((i['name'], i['id'], i['status']) for i in clusters)
 
         return (columns, output)


### PR DESCRIPTION
In the following patch [1] to Kostyor API it's proposed to return a list
of cluster objects instead of dictionary with 'clusters' key. This
approach follows Flask-RESTful practices.

This commit makes Kostyor CLI to be compatible with both outputs in
order to pass tests.

[1] https://github.com/sc68cal/Kostyor/pull/39
