### PR TITLE
Fix tox warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ setenv =
   KOSTYOR_PORT=5000
 deps =
   {[testenv]deps}
+whitelist_externals = bash
 commands =
         bash tools/functional_tests_env.sh
         ostestr


### PR DESCRIPTION
Tox shows warning "test command found but not installed in testenv"
during functional tests running. Add 'bash' to whitelist_externals
in tox.ini file to get rid of this message.
