### PR TITLE
Run functional tests with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
 setenv =
   KOSTYOR_HOST=127.0.0.1
   KOSTYOR_PORT=5000
+  OS_TEST_PATH=./kostyor_cli/tests/functional
 deps =
   {[testenv]deps}
 commands =


### PR DESCRIPTION
Command 'tox -e functional' runs unit tests instead of functional
since OS_TEST_PATH isn't set.

Set OS_TEST_PATH in [testenv:functional] section of tox.ini file.
