### PR TITLE
Implement 'list-discovery-methods' command

### DIFF
--- a/kostyor_cli/main.py
+++ b/kostyor_cli/main.py
@@ -249,14 +249,17 @@ class ListDiscoveryMethods(Lister):
     action = "list-discovery-methods"
 
     def take_action(self, parsed_args):
-        columns = ('Discovery Method', 'Description')
+        columns = ('Discovery Methods', )
 
-        data = (('OpenStack', 'OpenStack based discovery using Keystone API'),
-                ('Ansible-Inventory', "Discover a cluster, via ansible"),
-                ('Puppet', 'Discover a cluster, via puppet'),
-                ('Fuel', 'Discover a cluster, via Fuel'))
-
-        return (columns, data)
+        data = self.app.request.get(
+            '{}/discovery-methods'.format(self.app.baseurl)
+        )
+        result = ()
+        if data.status_code == 200:
+            result = ((method.capitalize(),) for method in data.json())
+        else:
+            _print_error_msg(data)
+        return (columns, result)
 
     def list():
         r = requests.get(

--- a/kostyor_cli/tests/unit/test_main.py
+++ b/kostyor_cli/tests/unit/test_main.py
@@ -175,3 +175,21 @@ class ServiceListTestCase(CLIBaseTestCase):
         self.app.run(self.command)
         self.app.request.get.assert_called_once_with(self.expected_request_str)
         main._print_error_msg.assert_called_once_with(self.resp)
+
+
+class ListDiscoveryMethodsTestCase(CLIBaseTestCase):
+    def setUp(self):
+        super(ListDiscoveryMethodsTestCase, self).setUp()
+        self.command = ['list-discovery-methods', ]
+        self.expected_request_str = 'http://1.1.1.1:22/discovery-methods'
+
+    def test_list_discovery_methods__status_200__success(self):
+        self.resp.status_code = 200
+        self.app.run(self.command)
+        self.app.request.get.assert_called_once_with(self.expected_request_str)
+        self.assertFalse(main._print_error_msg.called)
+
+    def test_list_discovery_methods__server_error__print_error_msg(self):
+        self.app.run(self.command)
+        self.app.request.get.assert_called_once_with(self.expected_request_str)
+        main._print_error_msg.assert_called_once_with(self.resp)


### PR DESCRIPTION
Implement REST API call to 'http://{host}:{port}/discovery-methods'
instead of returning hardcoded list of discovery methods.
