### PR TITLE
Force users to pass an upgrade driver to be used

### DIFF
--- a/kostyor_cli/commands/upgrade.py
+++ b/kostyor_cli/commands/upgrade.py
@@ -103,6 +103,10 @@ class UpgradeStart(ShowOne):
             'to_version',
             metavar='<to-version>',
             help='OpenStack release upgrade to.')
+        parser.add_argument(
+            'driver',
+            metavar='<driver>',
+            help='Driver to be used.')
         return parser
 
     def take_action(self, parsed_args):
@@ -111,6 +115,7 @@ class UpgradeStart(ShowOne):
             json={
                 'cluster_id': parsed_args.cluster,
                 'to_version': parsed_args.to_version,
+                'driver': parsed_args.driver,
             })
         resp.raise_for_status()
         return _showone(resp.json(), self.columns)

--- a/kostyor_cli/tests/unit/commands/test_upgrade.py
+++ b/kostyor_cli/tests/unit/commands/test_upgrade.py
@@ -34,12 +34,13 @@ class UpgradeShowTestCase(CLIBaseTestCase):
 class UpgradeStartTestCase(CLIBaseTestCase):
 
     def test_upgrade_start_correct_request(self):
-        self.app.run(['upgrade-start', '1234', 'mitaka'])
+        self.app.run(['upgrade-start', '1234', 'mitaka', 'openstack-ansible'])
 
         self.app.request.post.assert_called_once_with(
             'http://1.1.1.1:22/upgrades', json={
                 'cluster_id': '1234',
                 'to_version': 'mitaka',
+                'driver': 'openstack-ansible',
             }
         )
         self.resp.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
OpenStack upgrade procedure is deployment specific, so we need to use
a correct driver to orchestrate it. Since we may have different drivers
even for the same deployments, let's force users to pass a name of
driver to be used for upgrade.