### PR TITLE
Print services with multiple hosts if any

### DIFF
--- a/kostyor_cli/main.py
+++ b/kostyor_cli/main.py
@@ -239,9 +239,15 @@ class ServiceList(Lister):
         data = self.app.request.get(request_str)
         output = ()
         if data.status_code == 200:
+            def get_hosts(service):
+                # TODO: backward compatibility, to be dropped
+                if 'host_id' in data:
+                    return service['host_id']
+                return '\n'.join(service.get('hosts', []))
+
             output = ((service['id'],
                        service['name'],
-                       service['host_id'],
+                       get_hosts(service),
                        service['version']) for service in data.json())
         else:
             _print_error_msg(data)


### PR DESCRIPTION
Since Kostyor PR #103 [1], there's a new database schema where services
and hosts have Many-to-Many relationship. Hence, API response format
change was required. Likely, we are in prototype stage and can do it
freely as long as CI is passing.

This commit makes it possible to work with new API response while
maintaining backward compatibility with old one.

[1] https://github.com/Mirantis/Kostyor/pull/103