### PR TITLE
Make driver argument optional in upgrade case

### DIFF
--- a/kostyor_cli/commands/upgrade.py
+++ b/kostyor_cli/commands/upgrade.py
@@ -92,17 +92,20 @@ class UpgradeStart(ShowOne):
         parser.add_argument(
             'driver',
             metavar='<driver>',
+            nargs='?',
             help='Driver to be used.')
         return parser
 
     def take_action(self, parsed_args):
-        resp = self.app.request.post(
-            self.endpoint,
-            json={
-                'cluster_id': parsed_args.cluster,
-                'to_version': parsed_args.to_version,
-                'driver': parsed_args.driver,
-            })
+        payload = {
+            'cluster_id': parsed_args.cluster,
+            'to_version': parsed_args.to_version,
+        }
+
+        if parsed_args.driver is not None:
+            payload['driver'] = parsed_args.driver
+
+        resp = self.app.request.post(self.endpoint, json=payload)
         resp.raise_for_status()
         return showone(resp.json(), self.columns)
 

--- a/kostyor_cli/tests/unit/commands/test_upgrade.py
+++ b/kostyor_cli/tests/unit/commands/test_upgrade.py
@@ -45,6 +45,17 @@ class UpgradeStartTestCase(CLIBaseTestCase):
         )
         self.resp.raise_for_status.assert_called_once_with()
 
+    def test_upgrade_start_correct_request_wo_driver(self):
+        self.app.run(['upgrade-start', '1234', 'mitaka'])
+
+        self.app.request.post.assert_called_once_with(
+            'http://1.1.1.1:22/upgrades', json={
+                'cluster_id': '1234',
+                'to_version': 'mitaka',
+            }
+        )
+        self.resp.raise_for_status.assert_called_once_with()
+
 
 class UpgradeActionTestCase(CLIBaseTestCase):
 


### PR DESCRIPTION
The driver argument must be always the case for starting upgrade
procedure as operators must decide themselves which driver to use.
However, since Kostyor supports discovery mechanism and it's tied
to deployment the same way as upgrade drivers do, it might be a good
idea to consider driver that's used for discovery to be an upgrade
driver if it's not passed explicitly. Obviously, it's not implemented
so far but let's look in the future and make it happen.

Also, this commit unblocks integration gate of Kostyor master since it
doesn't pass driver when doing call to Kostyor CLI.