### PR TITLE
Propagate parameters to upgrade driver

### DIFF
--- a/kostyor_cli/commands/common.py
+++ b/kostyor_cli/commands/common.py
@@ -18,3 +18,11 @@ def showarray(entities, columns):
 def showone(entity, columns):
     labels, rows = showarray([entity], columns)
     return (labels, rows[0])
+
+
+def parse_kv(pairs):
+    def _to_kv(pair):
+        if '=' not in pair:
+            return (pair, True)
+        return pair.split('=', 1)
+    return dict([_to_kv(param) for param in pairs])

--- a/kostyor_cli/commands/discover.py
+++ b/kostyor_cli/commands/discover.py
@@ -3,7 +3,7 @@ import six
 from cliff.lister import Lister
 from cliff.show import ShowOne
 
-from kostyor_cli.commands.common import showarray, showone
+from kostyor_cli.commands.common import showarray, showone, parse_kv
 
 
 class DiscoverList(Lister):
@@ -55,18 +55,12 @@ class DiscoverRun(ShowOne):
         return parser
 
     def take_action(self, parsed_args):
-        def to_kv(pair):
-            if '=' not in pair:
-                return (pair, None)
-            return pair.split('=', 1)
-        parameters = dict([to_kv(param) for param in parsed_args.parameters])
-
         resp = self.app.request.post(
             self.endpoint,
             json={
                 'name': parsed_args.name,
                 'method': parsed_args.method,
-                'parameters': parameters,
+                'parameters': parse_kv(parsed_args.parameters),
             })
         resp.raise_for_status()
         return showone(resp.json(), self.columns)

--- a/kostyor_cli/commands/upgrade.py
+++ b/kostyor_cli/commands/upgrade.py
@@ -5,7 +5,7 @@ import six
 from cliff.lister import Lister
 from cliff.show import ShowOne
 
-from kostyor_cli.commands.common import showarray, showone
+from kostyor_cli.commands.common import showarray, showone, parse_kv
 
 
 class UpgradeList(Lister):
@@ -94,12 +94,19 @@ class UpgradeStart(ShowOne):
             metavar='<driver>',
             nargs='?',
             help='Driver to be used.')
+        parser.add_argument(
+            '-p', '--parameters',
+            type=lambda x: x if six.PY3 else x.decode(),
+            nargs='+',
+            default=[],
+            help='Key=Value pairs to be passed to discovering.')
         return parser
 
     def take_action(self, parsed_args):
         payload = {
             'cluster_id': parsed_args.cluster,
             'to_version': parsed_args.to_version,
+            'parameters': parse_kv(parsed_args.parameters),
         }
 
         if parsed_args.driver is not None:

--- a/kostyor_cli/tests/unit/commands/test_upgrade.py
+++ b/kostyor_cli/tests/unit/commands/test_upgrade.py
@@ -41,6 +41,7 @@ class UpgradeStartTestCase(CLIBaseTestCase):
                 'cluster_id': '1234',
                 'to_version': 'mitaka',
                 'driver': 'openstack-ansible',
+                'parameters': {},
             }
         )
         self.resp.raise_for_status.assert_called_once_with()
@@ -52,6 +53,30 @@ class UpgradeStartTestCase(CLIBaseTestCase):
             'http://1.1.1.1:22/upgrades', json={
                 'cluster_id': '1234',
                 'to_version': 'mitaka',
+                'parameters': {},
+            }
+        )
+        self.resp.raise_for_status.assert_called_once_with()
+
+    def test_upgrade_start_correct_parameters(self):
+        self.app.run([
+            'upgrade-start', '1234', 'mitaka', 'openstack-ansible',
+            '--parameters',
+            'root=/opt/openstack-ansible',
+            'debug',
+            'user=kostyor'
+        ])
+
+        self.app.request.post.assert_called_once_with(
+            'http://1.1.1.1:22/upgrades', json={
+                'cluster_id': '1234',
+                'to_version': 'mitaka',
+                'driver': 'openstack-ansible',
+                'parameters': {
+                    'root': '/opt/openstack-ansible',
+                    'debug': True,
+                    'user': 'kostyor',
+                },
             }
         )
         self.resp.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
So far there's no way to propagate any parameters to upgrade drivers
from API (or CLI), that's why such drivers as kostyor-openstack-ansible
requires to hardcode path to OpenStack Ansible root.

However, there's an activity to implement custom parameters support on
backend side, and this is a patch that adds support of client side.