### PR TITLE
Add support of new response format of `/clusters`

### DIFF
--- a/kostyor_cli/main.py
+++ b/kostyor_cli/main.py
@@ -73,7 +73,9 @@ class ClusterList(Lister):
     def take_action(self, parsed_args):
         columns = ('Cluster Name', 'Cluster ID', 'Status')
         data = self.app.request.get('{0}/clusters'.format(self.app.baseurl))
-        clusters = data.json()['clusters']
+        clusters = data.json()
+        if isinstance(clusters, dict):
+            clusters = clusters['clusters']
         output = ((i['name'], i['id'], i['status']) for i in clusters)
 
         return (columns, output)


### PR DESCRIPTION
Kostyor's API endpoints `/clusters` is used to respond with the
following JSON:

    {
        "clusters": [
            { ... },
            { ... },
            { ... }
        ]
    }

This format contains a redundant key `clusters`, as it does not carry
any sense. This commit introduces changes that ignores this key and
expects a JSON array as an endpoint response. I.e.:

    [
        { ... },
        { ... },
        { ... }
    ]

The compatibility with old API is preserved.