### PR TITLE
Propagate explicitly specified engine to API

### DIFF
--- a/kostyor_cli/commands/upgrade.py
+++ b/kostyor_cli/commands/upgrade.py
@@ -95,6 +95,11 @@ class UpgradeStart(ShowOne):
             nargs='?',
             help='Driver to be used.')
         parser.add_argument(
+            '-e', '--engine',
+            type=lambda x: x if six.PY3 else x.decode(),
+            default=None,
+            help='Engine to be used to orchestrate upgrades.')
+        parser.add_argument(
             '-p', '--parameters',
             type=lambda x: x if six.PY3 else x.decode(),
             nargs='+',
@@ -111,6 +116,9 @@ class UpgradeStart(ShowOne):
 
         if parsed_args.driver is not None:
             payload['driver'] = parsed_args.driver
+
+        if parsed_args.engine is not None:
+            payload['engine'] = parsed_args.engine
 
         resp = self.app.request.post(self.endpoint, json=payload)
         resp.raise_for_status()

--- a/kostyor_cli/tests/unit/commands/test_upgrade.py
+++ b/kostyor_cli/tests/unit/commands/test_upgrade.py
@@ -81,6 +81,19 @@ class UpgradeStartTestCase(CLIBaseTestCase):
         )
         self.resp.raise_for_status.assert_called_once_with()
 
+    def test_upgrade_start_correct_request_w_engine(self):
+        self.app.run(['upgrade-start', '1234', 'mitaka', '-e', 'the_engine'])
+
+        self.app.request.post.assert_called_once_with(
+            'http://1.1.1.1:22/upgrades', json={
+                'cluster_id': '1234',
+                'to_version': 'mitaka',
+                'engine': 'the_engine',
+                'parameters': {},
+            }
+        )
+        self.resp.raise_for_status.assert_called_once_with()
+
 
 class UpgradeActionTestCase(CLIBaseTestCase):
 


### PR DESCRIPTION
Recently Kostyor got an ability to receive an engine name to be used to
orchestrate upgrade. So this commit continues this effort by allowsing
to pass an engine name via command line argument `--engine`.